### PR TITLE
Fixed php5-mcrypt depends issue

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -3,6 +3,7 @@
 
 php5-gd
 php5-snmp
+php5-mcrypt
 php-pear
 python-mysqldb
 snmp


### PR DESCRIPTION
Fixes https://github.com/turnkeylinux/tracker/issues/487 by adding php5-mcrypt to plan
